### PR TITLE
gihtub-pr-branch-links 1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
-# gihtub-pr-branch-links [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/gihtub-pr-branch-links.svg)](https://www.npmjs.com/package/gihtub-pr-branch-links) [![Downloads](https://img.shields.io/npm/dt/gihtub-pr-branch-links.svg)](https://www.npmjs.com/package/gihtub-pr-branch-links) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# gihtub-pr-branch-links
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/gihtub-pr-branch-links.svg)](https://www.npmjs.com/package/gihtub-pr-branch-links) [![Downloads](https://img.shields.io/npm/dt/gihtub-pr-branch-links.svg)](https://www.npmjs.com/package/gihtub-pr-branch-links) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Open in a new tab the clicked branch on a pull request page.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gihtub-pr-branch-links",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Open in a new tab the clicked branch on a pull request page.",
   "main": "script.js",
   "scripts": {
@@ -54,6 +54,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
